### PR TITLE
Fix exception when deleting process icon cache

### DIFF
--- a/CoreDirector/Models/AppProcess.cs
+++ b/CoreDirector/Models/AppProcess.cs
@@ -85,6 +85,17 @@ namespace CoreDirector.Models
                     if (Type is CoreType.Default)
                     {
                         ConfigManager.Config.SavedProcesses.Remove(Key);
+
+                        IconBitmap?.Dispose();
+                        try
+                        {
+                            IconBitmap = Icon.ExtractAssociatedIcon(FilePath)?.ToBitmap();
+                        }
+                        catch
+                        {
+                            // ignored
+                        }
+
                         File.Delete(cachePath);
                     }
                     else


### PR DESCRIPTION
프로세스 설정을 '기본값'으로 되돌릴 때 아이콘 캐시 파일의 삭제를 시도하는데, 이미 `AppProcess.IconBitmap`에서 사용 중이기 때문에 삭제에 실패하고 아래 Exception이 발생하는 것 같습니다:

```
System.IO.IOException: The process cannot access the file 'C:\Users\...\AppData\Roaming\CoreDirector\Cache\3B7F9EDC348EC5027B767B65B3E5D5E5' because it is being used by another process.
   at System.IO.FileSystem.DeleteFile(String fullPath)
   at System.IO.File.Delete(String path)
   at CoreDirector.Models.AppProcess.<ApplyAffinity>b__19_0() in C:\...\CoreDirector\Models\AppProcess.cs:line 88
```

따라서 `AppProcess.ApplyInfinity()`에서 `ConfigManager.Save()`가 실행되지 못해, 프로그램을 껐다 켜면 방금 '기본값'으로 되돌렸던 프로세스가 다시 '성능 코어'나 '효율 코어' 모드로 설정되어 있는 모습이 확인됩니다.
일단 `AppProcess.IconBitmap`을 `Dispose()` 하고 새 아이콘을 할당하는 것으로 임시 조치를 해놓았습니다. 확인해주시면 감사하겠습니다.